### PR TITLE
Update collection mode to new API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+.idea
+Thumbs.db

--- a/Collections/CollectionsSuggestMode.php
+++ b/Collections/CollectionsSuggestMode.php
@@ -3,13 +3,13 @@
 namespace Statamic\Addons\Collections;
 
 use Statamic\Addons\Suggest\Modes\AbstractMode;
-use Statamic\API\Content;
+use Statamic\API\Collection;
 
 class CollectionsSuggestMode extends AbstractMode
 {
     public function suggestions()
     {
-        $collections = Content::collections();
+        $collections = Collection::all();
 
         $data = [];
         $index = 0;


### PR DESCRIPTION
I added the PHPStorm IDE settings and windows tempfiles to the .gitignore

`Content::collections()` was deprecated in v2.1